### PR TITLE
Modified plugin.json to suppress annoying deprecation warning and file not found warning.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
 	"id": "nodebb-plugin-category-info",
 	"name": "NodeBB Category Info",
 	"description": "Adds latest post information to each category block on the home page. Utilizes masonry to stack category blocks neatly",
-	"url": "https://github.com/psychobunny/nodebb-plugin-static-page",
+	"url": "https://github.com/psychobunny/nodebb-plugin-category-info",
 	"library": "./library.js",
 	"hooks": [
 		{
@@ -12,8 +12,8 @@
 			"hook": "filter:scripts.get", "method": "addScripts", "callbacked": false
 		}
 	],
-	"staticDir": "./static",
-	"css": [
-		"css/style.css"
-	]
+	"staticDirs": {
+		"css": "./static/css",
+		"js": "./static/js"
+	}
 }


### PR DESCRIPTION
warn: [plugins/nodebb-plugin-category-info] staticDir is deprecated, use staticDirs instead
warn: [meta/css] File not found! nodebb-plugin-category-info/css/style.css
